### PR TITLE
AMD patch to remove clang-build-analyzer

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -323,7 +323,7 @@ install_brew_and_packages() {
             gcc
             git
             ruby
-            clang-build-analyzer
+            python3
             zsh
             yq
         )


### PR DESCRIPTION
Remove clang-build-analyser
Install python3

If further functionality CBA provided is still required, it will be provided shortly.

Fixes: #14