### PR TITLE
Relax minimum DSM requirement to support DSM 7.1

### DIFF
--- a/install-synology-homebrew.sh
+++ b/install-synology-homebrew.sh
@@ -218,11 +218,20 @@ if [[ $DARWIN == 0 ]]; then
 
   # Convert versions into comparable integers
   current_version=$((majorversion * 100 + minorversion))
-  required_version=$((7 * 100 + 2))
+  min_supported_version=$((7 * 100 + 1))   # DSM 7.1
+  recommended_version=$((7 * 100 + 2))     # DSM 7.2+
 
-  if [[ "$current_version" -lt "$required_version" ]]; then
-    echo "Your DSM version does not meet minimum requirements. DSM 7.2 is required."
+  if [[ "$current_version" -lt "$min_supported_version" ]]; then
+    echo "❌ Your DSM version is too old."
+    echo "   Minimum supported version is DSM 7.1."
     exit 1
+  fi
+
+  if [[ "$current_version" -lt "$recommended_version" ]]; then
+    echo "⚠️  DSM $productversion detected."
+    echo "   DSM 7.2+ is recommended and fully validated."
+    echo "   DSM 7.1 is allowed but may have minor limitations."
+    echo ""
   fi
 
   MODE_LABEL="Advanced Install"


### PR DESCRIPTION
Fixes #22

## Summary

This PR relaxes the minimum supported Synology DSM version from **7.2 to 7.1**.

Based on community feedback and local testing, there does not appear to be
anything in the installer that strictly requires DSM 7.2. Allowing DSM 7.1
makes the project usable on older Synology hardware that cannot be upgraded
further.

The existing version check logic remains in place, and the installer clearly
reports the detected DSM version so users understand what is being supported.

## Scope of change

- Adjusts the minimum DSM version gate to allow DSM 7.1
- No package logic, paths, or runtime assumptions were loosened beyond this
- Behaviour remains unchanged for DSM 7.2+

## Testing

- Tested on Synology DSM 7.2 via SSH
- Installer completes successfully in both minimal and advanced modes

```bash
./install-synology-homebrew.sh
```

---

Thanks to the community for raising this and helping broaden support for older
but still perfectly capable Synology devices.
